### PR TITLE
work around gloo and benchmark build errors

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -170,6 +170,9 @@ prepare() {
   # https://bugs.archlinux.org/task/64981
   patch -N torch/utils/cpp_extension.py "${srcdir}"/fix_include_system.patch
 
+  # Work around https://github.com/facebookincubator/gloo/issues/332
+  patch -Np1 -i "${srcdir}"/fix-gloo.patch || true
+
   # Use system libuv
   patch -Np1 -i "${srcdir}"/use-system-libuv.patch
 
@@ -229,6 +232,10 @@ prepare() {
 }
 
 build() {
+  # Work around https://github.com/google/benchmark/issues/1398
+  # + https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
+  # + https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+  export CXXFLAGS="${CXXFLAGS} -w -Wno-error=maybe-uninitialized"
   # PYTORCH_ROCM_ARCH is an env var used to populate the PYTORCH_ROCM_ARCH export
   # PYTORCH_ROCM_ARCH="gfx908"
   # NOTE: It's your responbility to validate the value of $PYTORCH_ROCM_ARCH.

--- a/fix-gloo.patch
+++ b/fix-gloo.patch
@@ -1,0 +1,24 @@
+diff --git a/third_party/gloo/gloo/transport/tcp/device.cc b/third_party/gloo/gloo/transport/tcp/device.cc
+index 05cf0a4..6aa48f5 100644
+--- a/third_party/gloo/gloo/transport/tcp/device.cc
++++ b/third_party/gloo/gloo/transport/tcp/device.cc
+@@ -12,6 +12,7 @@
+ #include <netdb.h>
+ #include <netinet/in.h>
+ #include <string.h>
++#include <array>
+ 
+ #include "gloo/common/linux.h"
+ #include "gloo/common/logging.h"
+diff --git a/third_party/gloo/gloo/transport/tcp/tls/pair.cc b/third_party/gloo/gloo/transport/tcp/tls/pair.cc
+index 176fa5e..bf39bbf 100644
+--- a/third_party/gloo/gloo/transport/tcp/tls/pair.cc
++++ b/third_party/gloo/gloo/transport/tcp/tls/pair.cc
+@@ -17,6 +17,7 @@
+ 
+ #include <cstring>
+ #include <poll.h>
++#include <array>
+ 
+ namespace gloo {
+ namespace transport {


### PR DESCRIPTION
This isn't ideal, but it works around the GCC bugs preventing torch's benchmark dependency from compiling, and also works around a compilation error in gloo (patch adapted from https://github.com/facebookincubator/gloo/issues/332#issuecomment-1146812765)

After building, `sudo ln -s /usr/lib/libopenblas.so.3 /usr/lib/libcblas.so.3` is needed to make `import torch` work. This MR does not attempt to address that, since it's an easy-enough workaround.